### PR TITLE
Search como extension de Select

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ interface Request {
             Key        : String | null;
             Description: String | null;
             ...
-        }
+        };
+        Limit?: Number;
+        Offset?: Number;
     }
 }
 ```
@@ -34,7 +36,7 @@ interface Request {
 - `Insert` solo requiere de `Row`
 - `Delete` solo requiere de `PK`
 - `Update` requiere de `Row` y de `PK`
-- `Select` requiere de `PK`
+- `Search` requiere de `PK`
 
 ### Responses
 

--- a/plpgsql-test/db-SelectSearch.sql
+++ b/plpgsql-test/db-SelectSearch.sql
@@ -18,7 +18,15 @@ insert into "Table1"("Field1", "Field2", "Field3", "Field4") values
 ('a3', 'ab1', null, false),
 ('a4', 'bc2', 'c2', null),
 ('a5', 'bc2', null, null),
-('a6', 'bc3', 'c3', true);
+('', '', 'search1', null),
+('', '', 'search2', null),
+('', '', 'search3', null),
+('', '', 'search4', null),
+('', '', 'search5', null),
+('', '', 'search6', null),
+('', '', 'search7', null),
+('', '', 'search8', null),
+('', '', 'search9', null);
 
 create type t_enum as enum (
   'T-ENUM');

--- a/plpgsql-test/db-SelectSearch.sql
+++ b/plpgsql-test/db-SelectSearch.sql
@@ -18,6 +18,7 @@ insert into "Table1"("Field1", "Field2", "Field3", "Field4") values
 ('a3', 'ab1', null, false),
 ('a4', 'bc2', 'c2', null),
 ('a5', 'bc2', null, null),
+('a6', 'bc3', 'c3', true),
 ('', '', 'search1', null),
 ('', '', 'search2', null),
 ('', '', 'search3', null),

--- a/select.go
+++ b/select.go
@@ -28,9 +28,12 @@ func Select(
 		pk, ok := PK.(map[string]interface{})
 		if ok {
 			if condition, err = WherePK(pk, fieldMap, keys, &values, 0); err != nil {
-				return nil, err
+				if err != ErrorZeroParamsInPK {
+					return nil, err
+				}
+			} else {
+				condition = fmt.Sprintf("where %s", condition)
 			}
-			condition = fmt.Sprintf("where %s", condition)
 		}
 	}
 

--- a/select_test.go
+++ b/select_test.go
@@ -147,7 +147,7 @@ func Test_SelectSearch_Select_case3(t *testing.T) {
 	}
 
 	request := &jsonrpc.Request{}
-	request.ID = "jsonrpc-mock-id-sss-select-case-2"
+	request.ID = "jsonrpc-mock-id-sss-select-case-3"
 	request.Method = "Select"
 	request.Context = map[string]string{
 		"Source": "Table1",
@@ -201,6 +201,52 @@ func Test_SelectSearch_Select_case4(t *testing.T) {
 	request.Params = map[string]interface{}{
 		"PK": map[string]interface{}{
 			"Field2": "%c2",
+		},
+	}
+
+	send(conn, request)
+
+	scanner := bufio.NewScanner(conn)
+	scanner.Scan()
+	raw := scanner.Bytes()
+
+	response := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatal(err)
+		return
+	}
+	expected, err := getExpected(t)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	if !cmp.Equal(response, expected) {
+		strToWrite, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		t.Log(string(strToWrite))
+		t.Fatal(cmp.Diff(response, expected))
+	}
+}
+
+func Test_SelectSearch_Select_case5(t *testing.T) {
+	conn, err := net.Dial("tcp", srvSS.Address)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	request := &jsonrpc.Request{}
+	request.ID = "jsonrpc-mock-id-sss-select-case-5"
+	request.Method = "Search"
+	request.Context = map[string]string{
+		"Source": "Table1",
+	}
+	request.Params = map[string]interface{}{
+		"PK": map[string]interface{}{
+			"Field3": "search%",
 		},
 	}
 

--- a/select_test.go
+++ b/select_test.go
@@ -276,3 +276,50 @@ func Test_SelectSearch_Select_case5(t *testing.T) {
 		t.Fatal(cmp.Diff(response, expected))
 	}
 }
+
+func Test_SelectSearch_Select_case6(t *testing.T) {
+	conn, err := net.Dial("tcp", srvSS.Address)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	request := &jsonrpc.Request{}
+	request.ID = "jsonrpc-mock-id-sss-select-case-5"
+	request.Method = "Search"
+	request.Context = map[string]string{
+		"Source": "Table1",
+	}
+	request.Params = map[string]interface{}{
+		"PK": map[string]interface{}{
+			"Field3": "search%",
+		},
+		"Limit": 3,
+	}
+
+	send(conn, request)
+
+	scanner := bufio.NewScanner(conn)
+	scanner.Scan()
+	raw := scanner.Bytes()
+
+	response := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatal(err)
+		return
+	}
+	expected, err := getExpected(t)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	if !cmp.Equal(response, expected) {
+		strToWrite, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		t.Log(string(strToWrite))
+		t.Fatal(cmp.Diff(response, expected))
+	}
+}

--- a/server.go
+++ b/server.go
@@ -47,7 +47,7 @@ func (s *Server) RegisterSourceIDU(
 					params = Params
 				}
 			}
-			return Select(db, params, fields, source)
+			return Select(db, params, fields, source, false)
 		}
 	}(db))
 	s.rpc.RegisterSource("Search", source, func(db *sql.DB) jsonrpc.RemoteProcedure {
@@ -60,7 +60,13 @@ func (s *Server) RegisterSourceIDU(
 					params = Params
 				}
 			}
-			return Select(db, params, fields, source)
+			if params == nil {
+				return nil, ErrorUndefinedPK
+			}
+			if _, ok := params["Limit"]; !ok {
+				params["Limit"] = float64(6)
+			}
+			return Select(db, params, fields, source, true)
 		}
 	}(db))
 }

--- a/server.go
+++ b/server.go
@@ -50,6 +50,19 @@ func (s *Server) RegisterSourceIDU(
 			return Select(db, params, fields, source)
 		}
 	}(db))
+	s.rpc.RegisterSource("Search", source, func(db *sql.DB) jsonrpc.RemoteProcedure {
+		return func(request *jsonrpc.Request) (interface{}, error) {
+			var params map[string]interface{}
+			fields, _ := getFieldMap()
+			if request.Params != nil {
+				Params, ok := request.Params.(map[string]interface{})
+				if ok {
+					params = Params
+				}
+			}
+			return Select(db, params, fields, source)
+		}
+	}(db))
 }
 
 // RegisterTargetIDU whatever

--- a/snapshots/Test_SelectSearch_Select_case3.json
+++ b/snapshots/Test_SelectSearch_Select_case3.json
@@ -3,7 +3,7 @@
     "Source": "Table1"
   },
   "Error": null,
-  "ID": "jsonrpc-mock-id-sss-select-case-2",
+  "ID": "jsonrpc-mock-id-sss-select-case-3",
   "Method": "Select",
   "Result": [
     {

--- a/snapshots/Test_SelectSearch_Select_case5.json
+++ b/snapshots/Test_SelectSearch_Select_case5.json
@@ -1,0 +1,73 @@
+{
+  "Context": {
+    "Source": "Table1"
+  },
+  "Error": null,
+  "ID": "jsonrpc-mock-id-sss-select-case-5",
+  "Method": "Search",
+  "Result": [
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search1",
+      "Field4": null,
+      "ID": 6
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search2",
+      "Field4": null,
+      "ID": 7
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search3",
+      "Field4": null,
+      "ID": 8
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search4",
+      "Field4": null,
+      "ID": 9
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search5",
+      "Field4": null,
+      "ID": 10
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search6",
+      "Field4": null,
+      "ID": 11
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search7",
+      "Field4": null,
+      "ID": 12
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search8",
+      "Field4": null,
+      "ID": 13
+    },
+    {
+      "Field1": "",
+      "Field2": "",
+      "Field3": "search9",
+      "Field4": null,
+      "ID": 14
+    }
+  ]
+}

--- a/snapshots/Test_SelectSearch_Select_case5.json
+++ b/snapshots/Test_SelectSearch_Select_case5.json
@@ -11,63 +11,42 @@
       "Field2": "",
       "Field3": "search1",
       "Field4": null,
-      "ID": 6
+      "ID": 7
     },
     {
       "Field1": "",
       "Field2": "",
       "Field3": "search2",
       "Field4": null,
-      "ID": 7
+      "ID": 8
     },
     {
       "Field1": "",
       "Field2": "",
       "Field3": "search3",
       "Field4": null,
-      "ID": 8
+      "ID": 9
     },
     {
       "Field1": "",
       "Field2": "",
       "Field3": "search4",
       "Field4": null,
-      "ID": 9
+      "ID": 10
     },
     {
       "Field1": "",
       "Field2": "",
       "Field3": "search5",
       "Field4": null,
-      "ID": 10
+      "ID": 11
     },
     {
       "Field1": "",
       "Field2": "",
       "Field3": "search6",
       "Field4": null,
-      "ID": 11
-    },
-    {
-      "Field1": "",
-      "Field2": "",
-      "Field3": "search7",
-      "Field4": null,
       "ID": 12
-    },
-    {
-      "Field1": "",
-      "Field2": "",
-      "Field3": "search8",
-      "Field4": null,
-      "ID": 13
-    },
-    {
-      "Field1": "",
-      "Field2": "",
-      "Field3": "search9",
-      "Field4": null,
-      "ID": 14
     }
   ]
 }

--- a/snapshots/Test_SelectSearch_Select_case6.json
+++ b/snapshots/Test_SelectSearch_Select_case6.json
@@ -1,0 +1,31 @@
+{
+    "Context": {
+      "Source": "Table1"
+    },
+    "Error": null,
+    "ID": "jsonrpc-mock-id-sss-select-case-5",
+    "Method": "Search",
+    "Result": [
+      {
+        "Field1": "",
+        "Field2": "",
+        "Field3": "search1",
+        "Field4": null,
+        "ID": 7
+      },
+      {
+        "Field1": "",
+        "Field2": "",
+        "Field3": "search2",
+        "Field4": null,
+        "ID": 8
+      },
+      {
+        "Field1": "",
+        "Field2": "",
+        "Field3": "search3",
+        "Field4": null,
+        "ID": 9
+      }
+    ]
+  }

--- a/wherePK.go
+++ b/wherePK.go
@@ -107,7 +107,6 @@ func WherePK(
 						}
 					} else if t == reflect.String {
 						str, ok := value.(string)
-						fmt.Println(str, "TESTING IT")
 						if ok {
 							hasStart := false
 							if str[:1] == "%" {


### PR DESCRIPTION
Search es básicamente `Select` pero con ciertos parametros por defecto.
Por ejemplo, `Limit = 10`.

Otro aspecto a revisar es: En caso de que `PK` no esté definido en `Search` entonces lanzar un error. Para `Select` el parametro `PK` es opcional.